### PR TITLE
Create method to create and populate board instead of using rails aft…

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -5,7 +5,7 @@ class GamesController < ApplicationController
   end
 
   def create
-    @game = Game.create(game_params)
+    @game = Game.create_and_populate_board!(game_params)
     redirect_to root_path if @game.valid?
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,9 +7,9 @@ class Game < ActiveRecord::Base
   belongs_to :white_player, class_name: 'User'
 
   def self.create_and_populate_board!(params)
-    create(params)
-    populate_board!
-    self
+    new_game = create(params)
+    new_game.populate_board!
+    new_game
   end
 
   def populate_board!

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,7 +6,11 @@ class Game < ActiveRecord::Base
   belongs_to :black_player, class_name: 'User'
   belongs_to :white_player, class_name: 'User'
 
-  after_create :populate_board!
+  def self.create_and_populate_board!(params)
+    create(params)
+    populate_board!
+    self
+  end
 
   def populate_board!
     [0, 1, 6, 7].each do |row|

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe PiecesController, type: :controller do
   let(:fullgame) { FactoryGirl.create(:full_game) }
   let(:piece) { FactoryGirl.create(:piece) }
 
+  before do
+    fullgame.populate_board!
+  end
+
   describe '#show' do
     context 'user signed in' do
       before do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe Game, type: :model do
   end
 
   describe 'populate board!' do
+    before do
+      game.populate_board!
+    end
     it 'should have a white knight located at row 0 column 1' do
       expect(game.pieces.where(type: 'Knight', color: 'white').first.row_coordinate).to eq(0)
       expect(game.pieces.where(type: 'Knight', color: 'white').first.column_coordinate).to eq(1)

--- a/spec/models/pieces/pawn_spec.rb
+++ b/spec/models/pieces/pawn_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Pawn, type: :model do
   describe 'valid_move? for pawn method' do
-    before do
-      allow_any_instance_of(Game).to receive(:populate_board!).and_return true
-    end
-
     let(:game) { FactoryGirl.create(:game) }
     let(:b_pawn) { FactoryGirl.create(:pawn, game_id: game.id, row_coordinate: 1, column_coordinate: 1, color: 'black') }
     let(:w_pawn) { FactoryGirl.create(:pawn, game_id: game.id, row_coordinate: 5, column_coordinate: 1, color: 'white') }

--- a/spec/models/pieces/queen_spec.rb
+++ b/spec/models/pieces/queen_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Queen, type: :model do
   let(:queen) { FactoryGirl.create(:queen) }
 
   describe 'valid_move?' do
+    before do
+      queen.game.populate_board!
+    end
     it 'should return true if destination is (row 1, col 6)' do
       expect(queen.valid_move?(1, 6)).to eq true
     end

--- a/spec/models/pieces/rook_spec.rb
+++ b/spec/models/pieces/rook_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Rook, type: :model do
   let(:rook) { FactoryGirl.create(:rook) }
 
   describe 'valid_move?' do
+    before do
+      rook.game.populate_board!
+    end
     it 'should return true if destination is (row 2, col 3)' do
       expect(rook.valid_move?(2, 3)).to eq true
     end


### PR DESCRIPTION
…er_create
- Created self.create_and_populate_board method
- Call populate_board! in tests which require board to be populated namely:
  - pieces_controller_spec.rb
  - queen_spec.rb
  - rook_spec.rb
- Remove populate_board! method stub in pawn_spec.rb
