### PR TITLE
Fix double render bug and refactor pieces controller code

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -2,9 +2,6 @@ class PiecesController < ApplicationController
   before_action :authenticate_user!
   def update
     @piece = Piece.find(params[:id])
-    # return render json: { update_attempt: 'invalid move' } unless check_player_move(@piece)
-
-    check_player_move(@piece)
 
     origin_row = @piece.row_coordinate
     origin_col = @piece.column_coordinate
@@ -61,20 +58,8 @@ class PiecesController < ApplicationController
   end
 
   def check_move_validity(piece)
-    return render json: { update_attempt: 'invalid move' } unless piece.valid_move?(params[:piece][:row_coordinate].to_i, params[:piece][:column_coordinate].to_i)
+    return 'invalid move' unless piece.valid_move?(params[:piece][:row_coordinate].to_i, params[:piece][:column_coordinate].to_i)
 
-    move_result = piece.move_to!(params[:piece][:row_coordinate].to_i, params[:piece][:column_coordinate].to_i)
-    return render json: { update_attempt: 'invalid move' } if move_result == 'invalid'
-
-    move_result
-  end
-
-  def check_player_move(piece)
-    if piece.color == 'white'
-      return render json: { update_attempt: 'invalid move' } unless current_user.id == piece.game.white_player_id
-    else
-      return render json: { update_attempt: 'invalid move' } unless current_user.id == piece.game.black_player_id
-    end
-    true
+    piece.move_to!(params[:piece][:row_coordinate].to_i, params[:piece][:column_coordinate].to_i)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,13 +9,13 @@ class Piece < ActiveRecord::Base
     elsif (row_coordinate - destination_row).abs == (column_coordinate - destination_column).abs
       return check_diagonal(destination_row, destination_column)
     else
-      return 'invalid'
+      return 'invalid move'
     end
   end
 
   def move_to!(new_row_coordinate, new_column_coordinate)
-    return 'invalid' if color != game.current_move_color
-    return 'invalid' if type == 'King' && game.location_is_under_attack_by_color?(game.opposite_color(color), new_row_coordinate, new_column_coordinate)
+    return 'invalid move' if color != game.current_move_color
+    return 'invalid move' if type == 'King' && game.location_is_under_attack_by_color?(game.opposite_color(color), new_row_coordinate, new_column_coordinate)
     move_piece(new_row_coordinate, new_column_coordinate)
   end
 
@@ -40,7 +40,7 @@ class Piece < ActiveRecord::Base
           game.update_attributes(current_move_color: switch_turn_color)
           return 'castling'
         else
-          return 'invalid'
+          return 'invalid move'
         end
       end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Piece, type: :model do
       expect(game2.current_move_color).to eq 'black'
     end
 
-    it 'should return invalid' do
-      expect(black_pawn.move_to!(5, 4)).to eq 'invalid'
+    it 'should return invalid move' do
+      expect(black_pawn.move_to!(5, 4)).to eq 'invalid move'
     end
   end
 
@@ -75,15 +75,15 @@ RSpec.describe Piece, type: :model do
       expect(queen_side_black_rook.column_coordinate).to eq 3
     end
 
-    it 'should return invalid if castling is possible' do
+    it 'should return invalid move if castling is possible' do
       game
       Piece.destroy_all
       black_king.update_attributes(has_moved?: true)
-      expect(black_king.move_to!(queen_side_black_rook.row_coordinate, queen_side_black_rook.column_coordinate)).to eq 'invalid'
+      expect(black_king.move_to!(queen_side_black_rook.row_coordinate, queen_side_black_rook.column_coordinate)).to eq 'invalid move'
     end
 
-    it 'should return invalid' do
-      expect(@b_knight_2.move_to!(1, 4)).to eq 'invalid'
+    it 'should return invalid move' do
+      expect(@b_knight_2.move_to!(1, 4)).to eq 'invalid move'
     end
 
     it 'should return captured' do
@@ -97,8 +97,8 @@ RSpec.describe Piece, type: :model do
       expect(@w_rook_1.move_to!(7, 2)).to eq 'moved'
     end
 
-    it 'should return invalid' do
-      expect(@w_rook_1.move_to!(7, 3)).to eq 'invalid'
+    it 'should return invalid move' do
+      expect(@w_rook_1.move_to!(7, 3)).to eq 'invalid move'
     end
 
     it 'should return moved' do
@@ -116,28 +116,28 @@ RSpec.describe Piece, type: :model do
       expect(@w_bishop_1.column_coordinate).to eq nil
     end
 
-    it 'should return invalid if moving onto same color' do
+    it 'should return invalid move if moving onto same color' do
       @game.update_attributes(current_move_color: 'black')
       @game.reload
-      expect(@b_rook_1.move_to!(1, 0)).to eq 'invalid'
+      expect(@b_rook_1.move_to!(1, 0)).to eq 'invalid move'
       @b_pawn_1.reload
       expect(@b_pawn_1.row_coordinate).to eq 1
       expect(@b_pawn_1.column_coordinate).to eq 0
     end
 
     context 'cannot move into check' do
-      it 'should return invalid' do
+      it 'should return invalid move' do
         king = FactoryGirl.create(:king, color: 'white', game_id: game.id, row_coordinate: 3, column_coordinate: 4)
         FactoryGirl.create(:rook, color: 'black', game_id: game.id, row_coordinate: 1, column_coordinate: 3)
         FactoryGirl.create(:queen, color: 'black', game_id: game.id, row_coordinate: 2, column_coordinate: 6)
 
-        expect(king.move_to!(2, 3)).to eq 'invalid'
-        expect(king.move_to!(2, 4)).to eq 'invalid'
-        expect(king.move_to!(2, 5)).to eq 'invalid'
-        expect(king.move_to!(3, 3)).to eq 'invalid'
-        expect(king.move_to!(3, 5)).to eq 'invalid'
-        expect(king.move_to!(4, 3)).to eq 'invalid'
-        expect(king.move_to!(4, 4)).to eq 'invalid'
+        expect(king.move_to!(2, 3)).to eq 'invalid move'
+        expect(king.move_to!(2, 4)).to eq 'invalid move'
+        expect(king.move_to!(2, 5)).to eq 'invalid move'
+        expect(king.move_to!(3, 3)).to eq 'invalid move'
+        expect(king.move_to!(3, 5)).to eq 'invalid move'
+        expect(king.move_to!(4, 3)).to eq 'invalid move'
+        expect(king.move_to!(4, 4)).to eq 'invalid move'
         expect(king.move_to!(4, 5)).to eq 'moved'
       end
     end
@@ -157,7 +157,7 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'should return invalid' do
-      expect(@w_knight_1.obstructed?(4, 1)).to eq 'invalid'
+      expect(@w_knight_1.obstructed?(4, 1)).to eq 'invalid move'
     end
 
     it 'should return false' do
@@ -177,7 +177,7 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'should return invalid' do
-      expect(@w_rook_2.obstructed?(3, 5)).to eq 'invalid'
+      expect(@w_rook_2.obstructed?(3, 5)).to eq 'invalid move'
     end
 
     it 'should return false' do


### PR DESCRIPTION
- Refactor update action to avoid multiple calls to render method
- Ensure consistent return string value of 'invalid move' instead of occasional return of 'invalid' string when moves are invalid
- Remove redundant check on color of player moving piece in pieces controller